### PR TITLE
Rule N

### DIFF
--- a/include/PetriEngine/Reducer.h
+++ b/include/PetriEngine/Reducer.h
@@ -145,7 +145,7 @@ namespace PetriEngine {
         bool ReducebyRuleK(uint32_t* placeInQuery, bool remove_consumers);
         bool ReducebyRuleL(uint32_t* placeInQuery);
         bool ReducebyRuleM(uint32_t* placeInQuery);
-        bool ReducebyRuleN(uint32_t* placeInQuery);
+        bool ReducebyRuleN(uint32_t* placeInQuery, bool applyF);
 
         std::optional<std::pair<std::vector<bool>, std::vector<bool>>>relevant(const uint32_t* placeInQuery, bool remove_consumers);
         bool remove_irrelevant(const uint32_t* placeInQuery, const std::vector<bool> &tseen, const std::vector<bool> &pseen);

--- a/include/PetriEngine/Reducer.h
+++ b/include/PetriEngine/Reducer.h
@@ -159,6 +159,8 @@ namespace PetriEngine {
         void eraseTransition(std::vector<uint32_t>&, uint32_t);
         void skipTransition(uint32_t);
         void skipPlace(uint32_t);
+        void skipInArc(uint32_t, uint32_t);
+        void skipOutArc(uint32_t, uint32_t);
         std::string newTransName();
         
         bool consistent();

--- a/include/PetriEngine/Reducer.h
+++ b/include/PetriEngine/Reducer.h
@@ -114,7 +114,8 @@ namespace PetriEngine {
                 << "Applications of rule J: " << _ruleJ << "\n"
                 << "Applications of rule K: " << _ruleK << "\n"
                 << "Applications of rule L: " << _ruleL << "\n"
-                << "Applications of rule M: " << _ruleM << std::endl;
+                << "Applications of rule M: " << _ruleM << "\n"
+                << "Applications of rule N: " << _ruleN << std::endl;
         }
 
         void postFire(std::ostream&, const std::string& transition);
@@ -124,7 +125,7 @@ namespace PetriEngine {
     private:
         size_t _removedTransitions = 0;
         size_t _removedPlaces= 0;
-        size_t _ruleA = 0, _ruleB = 0, _ruleC = 0, _ruleD = 0, _ruleE = 0, _ruleF = 0, _ruleG = 0, _ruleH = 0, _ruleI = 0, _ruleJ = 0, _ruleK = 0, _ruleL = 0, _ruleM = 0;
+        size_t _ruleA = 0, _ruleB = 0, _ruleC = 0, _ruleD = 0, _ruleE = 0, _ruleF = 0, _ruleG = 0, _ruleH = 0, _ruleI = 0, _ruleJ = 0, _ruleK = 0, _ruleL = 0, _ruleM = 0, _ruleN = 0;
         PetriNetBuilder* parent = nullptr;
         bool reconstructTrace = false;
         std::chrono::high_resolution_clock::time_point _timer;
@@ -144,6 +145,7 @@ namespace PetriEngine {
         bool ReducebyRuleK(uint32_t* placeInQuery, bool remove_consumers);
         bool ReducebyRuleL(uint32_t* placeInQuery);
         bool ReducebyRuleM(uint32_t* placeInQuery);
+        bool ReducebyRuleN(uint32_t* placeInQuery);
 
         std::optional<std::pair<std::vector<bool>, std::vector<bool>>>relevant(const uint32_t* placeInQuery, bool remove_consumers);
         bool remove_irrelevant(const uint32_t* placeInQuery, const std::vector<bool> &tseen, const std::vector<bool> &pseen);

--- a/include/PetriEngine/options.h
+++ b/include/PetriEngine/options.h
@@ -49,7 +49,7 @@ struct options_t {
     char* modelfile = nullptr;
     char* queryfile = nullptr;
     int enablereduction = 1; // 0 ... disabled,  1 ... aggresive (default), 2 ... k-boundedness preserving, 3 ... selection
-    std::vector<uint32_t> reductions{8,12,2,3,4,5,7,9,6,0,1,11};
+    std::vector<uint32_t> reductions{8,12,2,3,4,13,5,7,9,6,0,1,11};
     int reductionTimeout = 60;
     bool stubbornreduction = true; 
     bool statespaceexploration = false;

--- a/src/PetriEngine/Reducer.cpp
+++ b/src/PetriEngine/Reducer.cpp
@@ -181,7 +181,36 @@ namespace PetriEngine {
         pl.producers.clear();
         assert(consistent());
     }
-    
+
+    void Reducer::skipInArc(uint32_t p, uint32_t t)
+    {
+        Place& place = parent->_places[p];
+        Transition& trans = parent->_transitions[t];
+
+        eraseTransition(place.consumers, t);;
+
+        Arc a;
+        a.place = p;
+        auto ait = std::lower_bound(trans.pre.begin(), trans.pre.end(), a);
+        assert(ait != trans.pre.end());
+        trans.pre.erase(ait);
+        assert(consistent());
+    }
+
+    void Reducer::skipOutArc(uint32_t t, uint32_t p)
+    {
+        Place& place = parent->_places[p];
+        Transition& trans = parent->_transitions[t];
+
+        eraseTransition(place.producers, t);;
+
+        Arc a;
+        a.place = p;
+        auto ait = std::lower_bound(trans.post.begin(), trans.post.end(), a);
+        assert(ait != trans.post.end());
+        trans.post.erase(ait);
+        assert(consistent());
+    }
     
     bool Reducer::consistent()
     {
@@ -1838,19 +1867,19 @@ namespace PetriEngine {
                 {
                     if (inArc->weight == outArc->weight)
                     {
-                        skipArc(inArc);
+                        skipInArc(p, cons);
                     }
                     else
                     {
                         inArc->weight -= outArc->weight;
                     }
-                    skipArc(outArc);
+                    skipOutArc(cons, p);
 
                     nonNegative -= 1;
                     continueReductions = true;
                     _ruleN += 1;
 
-                    // TODO Reconstruct trace??
+                    // TODO Reconstruct trace
                 }
             }
 

--- a/src/PetriEngine/Reducer.cpp
+++ b/src/PetriEngine/Reducer.cpp
@@ -1872,13 +1872,13 @@ namespace PetriEngine {
                 {
                     if (inArc->weight == outArc->weight)
                     {
-                        skipInArc(p, cons);
+                        skipOutArc(cons, p);
                     }
                     else
                     {
-                        inArc->weight -= outArc->weight;
+                        outArc->weight -= inArc->weight;
                     }
-                    skipOutArc(cons, p);
+                    skipInArc(p, cons);
 
                     nonNegative -= 1;
                     continueReductions = true;

--- a/src/PetriEngine/Reducer.cpp
+++ b/src/PetriEngine/Reducer.cpp
@@ -187,7 +187,7 @@ namespace PetriEngine {
         Place& place = parent->_places[p];
         Transition& trans = parent->_transitions[t];
 
-        eraseTransition(place.consumers, t);;
+        eraseTransition(place.consumers, t);
 
         Arc a;
         a.place = p;
@@ -202,7 +202,7 @@ namespace PetriEngine {
         Place& place = parent->_places[p];
         Transition& trans = parent->_transitions[t];
 
-        eraseTransition(place.producers, t);;
+        eraseTransition(place.producers, t);
 
         Arc a;
         a.place = p;

--- a/src/PetriEngine/Reducer.cpp
+++ b/src/PetriEngine/Reducer.cpp
@@ -1804,7 +1804,7 @@ namespace PetriEngine {
         return continueReductions;
     }
 
-    bool Reducer::ReducebyRuleN(uint32_t* placeInQuery) {
+    bool Reducer::ReducebyRuleN(uint32_t* placeInQuery, bool applyF) {
         // Redundant arc (and place) removal.
         // If a place p never disables a transition, we can remove its arc to the
         // transitions as long as the effect is maintained.
@@ -1888,7 +1888,7 @@ namespace PetriEngine {
                 }
             }
 
-            if (removePlace && nonNegative == 0 && numberofplaces - _removedPlaces > 1)
+            if (applyF && removePlace && nonNegative == 0 && numberofplaces - _removedPlaces > 1)
             {
                 if(reconstructTrace)
                 {
@@ -1901,6 +1901,7 @@ namespace PetriEngine {
                 }
                 skipPlace(p);
                 continueReductions = true;
+                _ruleF++;
             }
 
         }
@@ -1942,6 +1943,7 @@ namespace PetriEngine {
         this->reconstructTrace = reconstructTrace;
         if(reconstructTrace && enablereduction >= 1 && enablereduction <= 2)
             std::cout << "Rule H disabled when a trace is requested." << std::endl;
+        bool applyF = std::count(reduction.begin(), reduction.end(), 5);
         if (enablereduction == 2) { // for k-boundedness checking only rules A, D and H are applicable
             bool changed = true;
             while (changed && !hasTimedout()) {
@@ -1966,7 +1968,7 @@ namespace PetriEngine {
                         while(ReducebyRuleM(context.getQueryPlaceCount())) changed = true;
                         while(ReducebyRuleE(context.getQueryPlaceCount())) changed = true;
                         while(ReducebyRuleC(context.getQueryPlaceCount())) changed = true;
-                        while(ReducebyRuleN(context.getQueryPlaceCount())) changed = true;
+                        while(ReducebyRuleN(context.getQueryPlaceCount(), applyF)) changed = true;
                         while(ReducebyRuleF(context.getQueryPlaceCount())) changed = true;
                         while(ReducebyRuleL(context.getQueryPlaceCount())) changed = true;
                         if(!next_safe)
@@ -2066,7 +2068,7 @@ namespace PetriEngine {
                             if (ReducebyRuleM(context.getQueryPlaceCount())) changed = true;
                             break;
                         case 13:
-                            if (ReducebyRuleN(context.getQueryPlaceCount())) changed = true;
+                            if (ReducebyRuleN(context.getQueryPlaceCount(), applyF)) changed = true;
                             break;
                     }
 #ifndef NDEBUG

--- a/src/VerifyPN.cpp
+++ b/src/VerifyPN.cpp
@@ -255,7 +255,7 @@ ReturnValue parseOptions(int argc, char* argv[], options_t& options)
                 for(auto& qn : q)
                 {
                     int32_t n;
-                    if(sscanf(qn.c_str(), "%d", &n) != 1 || n < 0 || n > 12)
+                    if(sscanf(qn.c_str(), "%d", &n) != 1 || n < 0 || n > 13)
                     {
                         std::cerr << "Error in reduction rule choice : " << qn << std::endl;
                         return ErrorCode;

--- a/test_models/ruleN-001/model.pnml
+++ b/test_models/ruleN-001/model.pnml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<pnml xmlns="http://www.pnml.org/version-2009/grammar/pnml">
+    <net id="ComposedModel" type="http://www.pnml.org/version-2009/grammar/ptnet">
+        <page id="page0">
+            <place id="p">
+                <graphics>
+                    <position x="425" y="275"/>
+                </graphics>
+                <name>
+                    <graphics>
+                        <offset x="-5" y="35"/>
+                    </graphics>
+                    <text>p</text>
+                </name>
+                <initialMarking>
+                    <text>4</text>
+                </initialMarking>
+            </place>
+            <transition id="T0">
+                <name>
+                    <graphics>
+                        <offset x="-5" y="35"/>
+                    </graphics>
+                    <text>T0</text>
+                </name>
+                <graphics>
+                    <position x="345" y="275"/>
+                </graphics>
+            </transition>
+            <transition id="T1">
+                <name>
+                    <graphics>
+                        <offset x="-5" y="35"/>
+                    </graphics>
+                    <text>T1</text>
+                </name>
+                <graphics>
+                    <position x="425" y="195"/>
+                </graphics>
+            </transition>
+            <arc id="p_to_T0" source="p" target="T0" type="normal">
+                <inscription>
+                    <text>4</text>
+                </inscription>
+                <graphics>
+                    <position x="395" y="320"/>
+                </graphics>
+            </arc>
+            <arc id="p_to_T1" source="p" target="T1" type="normal">
+                <inscription>
+                    <text>2</text>
+                </inscription>
+                <graphics>
+                    <position x="470" y="250"/>
+                </graphics>
+            </arc>
+            <arc id="T0_to_p" source="T0" target="p" type="normal">
+                <inscription>
+                    <text>3</text>
+                </inscription>
+                <graphics>
+                    <position x="395" y="257"/>
+                </graphics>
+            </arc>
+            <arc id="T1_to_p" source="T1" target="p" type="normal">
+                <inscription>
+                    <text>3</text>
+                </inscription>
+                <graphics>
+                    <position x="410" y="250"/>
+                </graphics>
+            </arc>
+        </page>
+        <name>
+            <text>ComposedModel</text>
+        </name>
+    </net>
+</pnml>

--- a/test_models/ruleN-001/query.xml
+++ b/test_models/ruleN-001/query.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<property-set xmlns="http://tapaal.net/">
+  
+  <property>
+    <id>Query Comment/Name Here</id>
+    <description>Query Comment/Name Here</description>
+    <formula>
+      <exists-path>
+        <finally>
+          <integer-eq>
+            <tokens-count>
+              <place>p</place>
+            </tokens-count>
+            <integer-constant>5</integer-constant>
+          </integer-eq>
+        </finally>
+      </exists-path>
+    </formula>
+  </property>
+</property-set>

--- a/test_models/ruleN-002/model.pnml
+++ b/test_models/ruleN-002/model.pnml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<pnml xmlns="http://www.pnml.org/version-2009/grammar/pnml">
+    <net id="ComposedModel" type="http://www.pnml.org/version-2009/grammar/ptnet">
+        <page id="page0">
+            <place id="p">
+                <graphics>
+                    <position x="425" y="275"/>
+                </graphics>
+                <name>
+                    <graphics>
+                        <offset x="-5" y="35"/>
+                    </graphics>
+                    <text>p</text>
+                </name>
+                <initialMarking>
+                    <text>4</text>
+                </initialMarking>
+            </place>
+            <place id="P3">
+                <graphics>
+                    <position x="540" y="225"/>
+                </graphics>
+                <name>
+                    <graphics>
+                        <offset x="0" y="0"/>
+                    </graphics>
+                    <text>P3</text>
+                </name>
+                <initialMarking>
+                    <text>0</text>
+                </initialMarking>
+            </place>
+            <place id="P4">
+                <graphics>
+                    <position x="270" y="330"/>
+                </graphics>
+                <name>
+                    <graphics>
+                        <offset x="0" y="0"/>
+                    </graphics>
+                    <text>P4</text>
+                </name>
+                <initialMarking>
+                    <text>2</text>
+                </initialMarking>
+            </place>
+            <transition id="T0">
+                <name>
+                    <graphics>
+                        <offset x="-5" y="35"/>
+                    </graphics>
+                    <text>T0</text>
+                </name>
+                <graphics>
+                    <position x="345" y="275"/>
+                </graphics>
+            </transition>
+            <transition id="T1">
+                <name>
+                    <graphics>
+                        <offset x="-5" y="35"/>
+                    </graphics>
+                    <text>T1</text>
+                </name>
+                <graphics>
+                    <position x="425" y="195"/>
+                </graphics>
+            </transition>
+            <transition id="T5">
+                <name>
+                    <graphics>
+                        <offset x="0" y="0"/>
+                    </graphics>
+                    <text>T5</text>
+                </name>
+                <graphics>
+                    <position x="375" y="375"/>
+                </graphics>
+            </transition>
+            <transition id="T6">
+                <name>
+                    <graphics>
+                        <offset x="0" y="0"/>
+                    </graphics>
+                    <text>T6</text>
+                </name>
+                <graphics>
+                    <position x="495" y="315"/>
+                </graphics>
+            </transition>
+            <arc id="p_to_T0" source="p" target="T0" type="normal">
+                <inscription>
+                    <text>4</text>
+                </inscription>
+                <graphics>
+                    <position x="395" y="320"/>
+                </graphics>
+            </arc>
+            <arc id="p_to_T1" source="p" target="T1" type="normal">
+                <inscription>
+                    <text>2</text>
+                </inscription>
+                <graphics>
+                    <position x="470" y="250"/>
+                </graphics>
+            </arc>
+            <arc id="P4_to_T0" source="P4" target="T0" type="normal"/>
+            <arc id="P4_to_T5" source="P4" target="T5" type="normal"/>
+            <arc id="p_to_T6" source="p" target="T6" type="normal"/>
+            <arc id="T0_to_p" source="T0" target="p" type="normal">
+                <inscription>
+                    <text>3</text>
+                </inscription>
+                <graphics>
+                    <position x="395" y="257"/>
+                </graphics>
+            </arc>
+            <arc id="T1_to_p" source="T1" target="p" type="normal">
+                <inscription>
+                    <text>3</text>
+                </inscription>
+                <graphics>
+                    <position x="410" y="250"/>
+                </graphics>
+            </arc>
+            <arc id="T1_to_P3" source="T1" target="P3" type="normal"/>
+            <arc id="T5_to_p" source="T5" target="p" type="normal"/>
+            <arc id="T6_to_p" source="T6" target="p" type="normal">
+                <graphics>
+                    <position x="460" y="328"/>
+                </graphics>
+            </arc>
+            <arc id="T6_to_P3" source="T6" target="P3" type="normal"/>
+        </page>
+        <name>
+            <text>ComposedModel</text>
+        </name>
+    </net>
+</pnml>

--- a/test_models/ruleN-002/query.xml
+++ b/test_models/ruleN-002/query.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<property-set xmlns="http://tapaal.net/">
+  
+  <property>
+    <id>Query Comment/Name Here</id>
+    <description>Query Comment/Name Here</description>
+    <formula>
+      <exists-path>
+        <finally>
+          <integer-eq>
+            <tokens-count>
+              <place>p</place>
+            </tokens-count>
+            <integer-constant>5</integer-constant>
+          </integer-eq>
+        </finally>
+      </exists-path>
+    </formula>
+  </property>
+</property-set>


### PR DESCRIPTION
Rule N: The lower bound number of tokens at a place `p` is given by the minimum of the initial marking and the number of tokens returned by any consuming transition with negative effect. We can then find transitions, which are never disabled by `p` and remove the transition's dependency on `p` (since it is unnecessary), as long as we maintain the effect of firing the transition. If we end up removing all dependencies, then we can also remove `p`, unless `p` inhibits anything or appears in the query (this case is equivalent to applying rule F).