### PR TITLE
Allow rule N to remove always inhibited transitions

### DIFF
--- a/src/PetriEngine/Reducer.cpp
+++ b/src/PetriEngine/Reducer.cpp
@@ -1807,7 +1807,8 @@ namespace PetriEngine {
     bool Reducer::ReducebyRuleN(uint32_t* placeInQuery, bool applyF) {
         // Redundant arc (and place) removal.
         // If a place p never disables a transition, we can remove its arc to the
-        // transitions as long as the effect is maintained.
+        // transitions as long as the effect is maintained. Similarly, we can remove
+        // transitions that are always inhibited.
 
         bool continueReductions = false;
         const size_t numberofplaces = parent->numberOfPlaces();
@@ -1818,7 +1819,7 @@ namespace PetriEngine {
             Place& place = parent->_places[p];
             if (place.skip) continue;
 
-            bool removePlace = !place.inhib && placeInQuery[p] == 0;
+            bool removePlace = placeInQuery[p] == 0;
 
             // Use tflags to mark transitions with negative effect
             _tflags.resize(parent->_transitions.size(), 0);
@@ -1827,17 +1828,27 @@ namespace PetriEngine {
             // Assume all consumers are disableable and non-negative until proven otherwise. Used to apply F.
             uint32_t disableableNonNegative = place.consumers.size();
 
+            uint32_t inhibArcs = 0;
+
             uint32_t low = parent->initialMarking[p];
 
             for (uint cons : place.consumers)
             {
                 Transition& tran = getTransition(cons);
+                auto inArc = getInArc(p, tran);
+
+                if (inArc->inhib)
+                {
+                    inhibArcs++;
+                    continue;
+                }
 
                 auto outArc = getOutArc(tran, p);
+
                 if (outArc != tran.post.end()) {
 
                     uint32_t outArcWeight = outArc->weight;
-                    uint32_t inArcWeight = getInArc(p, tran)->weight;
+                    uint32_t inArcWeight = inArc->weight;
 
                     if (outArcWeight < inArcWeight)
                     {
@@ -1861,36 +1872,50 @@ namespace PetriEngine {
             // Consumer arcs exists, but none will have a weight lower than 0
             if (!place.consumers.empty() && low == 0) continue;
 
+            std::set<uint32_t> alwaysInhibited;
+
             for (uint cons : place.consumers)
             {
                 if (_tflags[cons] == 1) continue;
 
                 Transition& tran = getTransition(cons);
-
-                auto outArc = getOutArc(tran, p);
                 auto inArc = getInArc(p, tran);
 
                 if (inArc->weight <= low)
                 {
-                    if (inArc->weight == outArc->weight)
+                    if (inArc->inhib)
                     {
-                        skipOutArc(cons, p);
+                        alwaysInhibited.insert(cons);
                     }
                     else
                     {
-                        outArc->weight -= inArc->weight;
+                        auto outArc = getOutArc(tran, p);
+                        if (inArc->weight == outArc->weight)
+                        {
+                            skipOutArc(cons, p);
+                        }
+                        else
+                        {
+                            outArc->weight -= inArc->weight;
+                        }
+                        skipInArc(p, cons);
+
+                        disableableNonNegative -= 1;
+                        continueReductions = true;
+                        _ruleN += 1;
+
+                        // TODO Reconstruct trace
                     }
-                    skipInArc(p, cons);
-
-                    disableableNonNegative -= 1;
-                    continueReductions = true;
-                    _ruleN += 1;
-
-                    // TODO Reconstruct trace
                 }
             }
 
-            if (applyF && removePlace && disableableNonNegative == 0 && numberofplaces - _removedPlaces > 1)
+            inhibArcs -= alwaysInhibited.size();
+            _ruleN += alwaysInhibited.size();
+
+            for (auto inhibited : alwaysInhibited)
+                skipTransition(inhibited);
+
+            if (applyF && removePlace && inhibArcs == 0 && disableableNonNegative == 0 && numberofplaces - _removedPlaces > 1)
             {
                 if(reconstructTrace)
                 {

--- a/test_models/ruleN-003/model.pnml
+++ b/test_models/ruleN-003/model.pnml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<pnml xmlns="http://www.pnml.org/version-2009/grammar/pnml">
+    <net id="ComposedModel" type="http://www.pnml.org/version-2009/grammar/ptnet">
+        <page id="page0">
+            <place id="P0">
+                <graphics>
+                    <position x="315" y="225"/>
+                </graphics>
+                <name>
+                    <graphics>
+                        <offset x="0" y="0"/>
+                    </graphics>
+                    <text>P0</text>
+                </name>
+                <initialMarking>
+                    <text>3</text>
+                </initialMarking>
+            </place>
+            <place id="P1">
+                <graphics>
+                    <position x="240" y="315"/>
+                </graphics>
+                <name>
+                    <graphics>
+                        <offset x="0" y="0"/>
+                    </graphics>
+                    <text>P1</text>
+                </name>
+                <initialMarking>
+                    <text>0</text>
+                </initialMarking>
+            </place>
+            <place id="P2">
+                <graphics>
+                    <position x="240" y="150"/>
+                </graphics>
+                <name>
+                    <graphics>
+                        <offset x="0" y="0"/>
+                    </graphics>
+                    <text>P2</text>
+                </name>
+                <initialMarking>
+                    <text>0</text>
+                </initialMarking>
+            </place>
+            <transition id="T0">
+                <name>
+                    <graphics>
+                        <offset x="0" y="0"/>
+                    </graphics>
+                    <text>T0</text>
+                </name>
+                <graphics>
+                    <position x="315" y="150"/>
+                </graphics>
+            </transition>
+            <transition id="T1">
+                <name>
+                    <graphics>
+                        <offset x="0" y="0"/>
+                    </graphics>
+                    <text>T1</text>
+                </name>
+                <graphics>
+                    <position x="315" y="315"/>
+                </graphics>
+            </transition>
+            <transition id="T2">
+                <name>
+                    <graphics>
+                        <offset x="0" y="0"/>
+                    </graphics>
+                    <text>T2</text>
+                </name>
+                <graphics>
+                    <position x="240" y="225"/>
+                </graphics>
+            </transition>
+            <arc id="P0_to_T0" source="P0" target="T0" type="normal">
+                <inscription>
+                    <text>3</text>
+                </inscription>
+                <graphics>
+                    <position x="356" y="194"/>
+                </graphics>
+            </arc>
+            <arc id="P0_to_T1" source="P0" target="T1" type="normal">
+                <graphics>
+                    <position x="303" y="288"/>
+                </graphics>
+            </arc>
+            <arc id="P1_to_T2" source="P1" target="T2" type="normal"/>
+            <arc id="T0_to_P0" source="T0" target="P0" type="normal">
+                <inscription>
+                    <text>2</text>
+                </inscription>
+                <graphics>
+                    <position x="299" y="197"/>
+                </graphics>
+            </arc>
+            <arc id="T1_to_P0" source="T1" target="P0" type="normal">
+                <graphics>
+                    <position x="358" y="292"/>
+                </graphics>
+            </arc>
+            <arc id="T2_to_P2" source="T2" target="P2" type="normal"/>
+            <arc id="T1_to_P1" source="T1" target="P1" type="normal"/>
+            <arc id="T0_to_P2" source="T0" target="P2" type="normal"/>
+            <arc id="P0_to_T2" source="P0" target="T2" type="inhibitor"/>
+        </page>
+        <name>
+            <text>ComposedModel</text>
+        </name>
+    </net>
+</pnml>

--- a/test_models/ruleN-003/query.xml
+++ b/test_models/ruleN-003/query.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<property-set xmlns="http://tapaal.net/">
+  
+  <property>
+    <id>Query Comment/Name Here</id>
+    <description>Query Comment/Name Here</description>
+    <formula>
+      <exists-path>
+        <finally>
+          <integer-eq>
+            <tokens-count>
+              <place>P2</place>
+            </tokens-count>
+            <integer-constant>2</integer-constant>
+          </integer-eq>
+        </finally>
+      </exists-path>
+    </formula>
+  </property>
+</property-set>


### PR DESCRIPTION
* Rule N no longer consider inhibitor arcs as out arcs (allows for more reduction).
* Rule N will now remove transitions that are always inhibited, due to the inhibitor's weight being less or equal to the lower bound. Supervisors probably wants this as a seperate rule, but for now it will be rule N.