### PR TITLE
use unsigned long in initial marking, instead of long long

### DIFF
--- a/src/PetriParse/PNMLParser.cpp
+++ b/src/PetriParse/PNMLParser.cpp
@@ -604,7 +604,7 @@ void PNMLParser::parsePlace(rapidxml::xml_node<>* element) {
     std::string id(element->first_attribute("id")->value());
     
     auto initial = element->first_attribute("initialMarking");
-    unsigned long initialMarking = 0;
+    uint32_t initialMarking = 0;
     PetriEngine::Colored::Multiset hlinitialMarking;
     const PetriEngine::Colored::ColorType* type = nullptr;
     if(initial)
@@ -628,9 +628,9 @@ void PNMLParser::parsePlace(rapidxml::xml_node<>* element) {
         }
     }
     
-    if(initialMarking > std::numeric_limits<unsigned long>::max())
+    if(initialMarking > std::numeric_limits<uint32_t>::max())
     {
-        std::cerr << "Number of tokens in " << id << " exceeded " << std::numeric_limits<unsigned long>::max() << std::endl;
+        std::cerr << "Number of tokens in " << id << " exceeded " << std::numeric_limits<uint32_t>::max() << std::endl;
         exit(ErrorCode);
     }
     //Create place

--- a/src/PetriParse/PNMLParser.cpp
+++ b/src/PetriParse/PNMLParser.cpp
@@ -604,7 +604,7 @@ void PNMLParser::parsePlace(rapidxml::xml_node<>* element) {
     std::string id(element->first_attribute("id")->value());
     
     auto initial = element->first_attribute("initialMarking");
-    long long initialMarking = 0;
+    unsigned long initialMarking = 0;
     PetriEngine::Colored::Multiset hlinitialMarking;
     const PetriEngine::Colored::ColorType* type = nullptr;
     if(initial)
@@ -628,9 +628,9 @@ void PNMLParser::parsePlace(rapidxml::xml_node<>* element) {
         }
     }
     
-    if(initialMarking > std::numeric_limits<int>::max())
+    if(initialMarking > std::numeric_limits<unsigned long>::max())
     {
-        std::cerr << "Number of tokens in " << id << " exceeded " << std::numeric_limits<int>::max() << std::endl;
+        std::cerr << "Number of tokens in " << id << " exceeded " << std::numeric_limits<unsigned long>::max() << std::endl;
         exit(ErrorCode);
     }
     //Create place


### PR DESCRIPTION
Negative values for initial markings not needed, use unsigned long instead to handle larger markings
Is now able to parse and verify properties in the `GPPP-PT-C0010N1000000000` model (has a marking of 4000000000 which was above the previous limit)
As far as I can see, this won't have any negative effect, and we might even save memory.

The previous implementation even had support for large markings, but used the max of a normal INT in its check, instead of the long long max 